### PR TITLE
add numa_node attribute and getter to namespace

### DIFF
--- a/lib/libndctl.c
+++ b/lib/libndctl.c
@@ -229,6 +229,7 @@ struct ndctl_lbasize {
  * @namespace_path: devpath for namespace device
  * @bdev: associated block_device of a namespace
  * @size: unsigned
+ * @numa_node: numa node attribute
  *
  * A 'namespace' is the resulting device after region-aliasing and
  * label-parsing is resolved.
@@ -246,6 +247,7 @@ struct ndctl_namespace {
 	char *alt_name;
 	uuid_t uuid;
 	struct ndctl_lbasize lbasize;
+	int numa_node;
 };
 
 /**
@@ -2585,6 +2587,11 @@ static int add_namespace(void *parent, int id, const char *ndns_base)
 		goto err_read;
 	ndns->raw_mode = strtoul(buf, NULL, 0);
 
+	sprintf(path, "%s/numa_node", ndns_base);
+	if (sysfs_read_attr(ctx, path, buf) < 0)
+		goto err_read;
+	ndns->numa_node = strtol(buf, NULL, 0);
+
 	switch (ndns->type) {
 	case ND_DEVICE_NAMESPACE_BLK:
 		sprintf(path, "%s/sector_size", ndns_base);
@@ -3189,6 +3196,11 @@ NDCTL_EXPORT int ndctl_namespace_set_size(struct ndctl_namespace *ndns,
 				ndctl_namespace_get_type(ndns));
 		return -ENXIO;
 	}
+}
+
+NDCTL_EXPORT int ndctl_namespace_get_numa_node(struct ndctl_namespace *ndns)
+{
+    return ndns->numa_node;
 }
 
 NDCTL_EXPORT int ndctl_namespace_delete(struct ndctl_namespace *ndns)

--- a/lib/libndctl.sym
+++ b/lib/libndctl.sym
@@ -153,6 +153,7 @@ global:
 	ndctl_namespace_set_sector_size;
 	ndctl_namespace_get_raw_mode;
 	ndctl_namespace_set_raw_mode;
+	ndctl_namespace_get_numa_node;
 	ndctl_btt_get_first;
 	ndctl_btt_get_next;
 	ndctl_btt_get_ctx;

--- a/lib/ndctl/libndctl.h
+++ b/lib/ndctl/libndctl.h
@@ -354,6 +354,7 @@ int ndctl_namespace_set_sector_size(struct ndctl_namespace *ndns,
 		unsigned int sector_size);
 int ndctl_namespace_get_raw_mode(struct ndctl_namespace *ndns);
 int ndctl_namespace_set_raw_mode(struct ndctl_namespace *ndns, int raw_mode);
+int ndctl_namespace_get_numa_node(struct ndctl_namespace *ndns);
 
 struct ndctl_btt;
 struct ndctl_btt *ndctl_btt_get_first(struct ndctl_region *region);


### PR DESCRIPTION
- add numa_node attribute to struct ndctl_namespace
- read in numa_node from sysfs when initializing a ndctl_namespace instance
- add getter