### PR TITLE
Redundant assigment of tmp to itself

### DIFF
--- a/test/mmap.c
+++ b/test/mmap.c
@@ -59,7 +59,6 @@ static void test_read(unsigned long *p, size_t size)
 	start();
 	for (i=0, wp=p; i<(size/sizeof(*wp)); i++)
 		tmp = *wp++;
-	tmp = tmp;
 	timeval = stop();
 	printf("Read : %10llu usec\n", timeval);
 }


### PR DESCRIPTION
Redundant assignment of tmp to itself in the read call.
[Not very sure if this is made to avoid any compiler optimization on the volatile variable]
If it was not to avoid any compiler peculiar stuff  then this patch should help to remove the redundant 
assignment  
