### PR TITLE
ndctl: support machines without numa

### DIFF
--- a/ndctl/lib/libndctl.c
+++ b/ndctl/lib/libndctl.c
@@ -2779,9 +2779,11 @@ static int add_namespace(void *parent, int id, const char *ndns_base)
 	ndns->raw_mode = strtoul(buf, NULL, 0);
 
 	sprintf(path, "%s/numa_node", ndns_base);
-	if (sysfs_read_attr(ctx, path, buf) < 0)
-		goto err_read;
-	ndns->numa_node = strtol(buf, NULL, 0);
+	if (sysfs_read_attr(ctx, path, buf) < 0) {
+		ndns->numa_node = 0;
+	} else {
+		ndns->numa_node = strtol(buf, NULL, 0);
+	}
 
 	switch (ndns->type) {
 	case ND_DEVICE_NAMESPACE_BLK:


### PR DESCRIPTION
Currently when using ndctl in machines that doesn't have numa, the ndctl command fails because it fails to find the numa_node attribute in syses