### PR TITLE
test: Fix 'make check' LDFLAGS

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -89,4 +89,6 @@ multi_pmem_SOURCES = \
 multi_pmem_LDADD = \
 		$(LIBNDCTL_LIB) \
 		$(JSON_LIBS) \
+		$(UUID_LIBS) \
+		$(KMOD_LIBS) \
 		../libutil.a


### PR DESCRIPTION
Current 'make check' break on some scenarios due to not linking against
uuid and kmod libraries. Causing the following error:

 /usr/bin/ld: multi-pmem.o: undefined reference to symbol 'uuid_unparse@@UUID_1.0'
 //lib/powerpc64le-linux-gnu/libuuid.so.1: error adding symbols: DSO missing from command line
 collect2: error: ld returned 1 exit status
 Makefile:792: recipe for target 'multi-pmem' failed
 Makefile:791: *** [multi-pmem] Error 1

 #0  multi-pmem at /home/breno/ndctl/ndctl/test/Makefile:791
 Makefile:1197: recipe for target 'check-am' failed
 Makefile:1196: *** [check-am] Error 2

This patch just put the explic libraries on LDFLAGS.

Signed-off-by: Breno Leitao <leitao@debian.org.