### PR TITLE
util: Enable ndctl to compile on non-glibc envs

### DIFF
--- a/util/log.h
+++ b/util/log.h
@@ -62,7 +62,8 @@ do { \
 #  ifdef HAVE___SECURE_GETENV
 #    define secure_getenv __secure_getenv
 #  else
-#    error neither secure_getenv nor __secure_getenv is available
+#    warning neither secure_getenv nor __secure_getenv is available.
+#    define secure_getenv getenv
 #  endif
 #endif
 


### PR DESCRIPTION
Currently ndctl does not build on non-glibc environments, as musl.

It fails because neither functions secure_getenv() nor
_secure_getenv() are available. These functions are only available
on systems with glibc version 2.17 or later.

This patch just make a fallback to getenv() if the secure functions
are missing.

Signed-off-by: Breno Leitao <breno.leitao@gmail.com>