### PR TITLE
daxctl/Makefile: add UUID_LIBS to LDFLAGS

### DIFF
--- a/daxctl/Makefile.am
+++ b/daxctl/Makefile.am
@@ -10,4 +10,5 @@ daxctl_SOURCES =\
 daxctl_LDADD =\
 	lib/libdaxctl.la \
 	../libutil.a \
+	$(UUID_LIBS) \
 	$(JSON_LIBS)


### PR DESCRIPTION
Had to add "-luuid" in order for daxctl to link on Ubuntu 16.04. This patch
makes the needed amendment to daxctl's Makefile.am.

Signed-off-by: Joe Konno <joe.konno@intel.com>