### PR TITLE
daxctl: use realpath instead of canonicalize_file_name

### DIFF
--- a/daxctl/lib/libdaxctl.c
+++ b/daxctl/lib/libdaxctl.c
@@ -459,7 +459,7 @@ static char *dax_region_path(const char *base, const char *device)
 		return NULL;
 
 	/* dax_region must be the instance's direct parent */
-	region_path = canonicalize_file_name(path);
+	region_path = realpath(path, NULL);
 	free(path);
 	if (!region_path)
 		return NULL;


### PR DESCRIPTION
This will allow for building ndctl with musl.
_canonicalize_file_name_ is specific to glibc: https://sourceware.org/git/?p=glibc.git;a=blob;f=stdlib/canonicalize.c;h=30825a91b824ec77793affdc53a3cbed25d3a021;hb=HEAD#l245
and is implemented by calling
`return realpath(path, NULL);`

musl does not implement _canonicalize_file_name_, but it supports calling _realpath_ with _resolved_path == NULL_
https://git.musl-libc.org/cgit/musl/tree/src/misc/realpath.c?id=dfddd43256f7ad4bad991eeff5cc51772595f327#n41