### PR TITLE
ndctl: add info `CONFIG_DEV_DAX_PMEM=m` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ git://git.kernel.org/pub/scm/linux/kernel/git/nvdimm/nvdimm.git`
 `CONFIG_ND_BLK=m`  
 `CONFIG_BTT=y`  
 `CONFIG_NVDIMM_PFN=y`  
-`CONFIG_NVDIMM_DAX=y`  
+`CONFIG_NVDIMM_DAX=y` 
+`CONFIG_DEV_DAX_PMEM=m`
 
 4. Build and install the unit test enabled libnvdimm modules in the
    following order.  The unit test modules need to be in place prior to

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git://git.kernel.org/pub/scm/linux/kernel/git/nvdimm/nvdimm.git`
 `CONFIG_ND_BLK=m`  
 `CONFIG_BTT=y`  
 `CONFIG_NVDIMM_PFN=y`  
-`CONFIG_NVDIMM_DAX=y` 
+`CONFIG_NVDIMM_DAX=y`  
 `CONFIG_DEV_DAX_PMEM=m`
 
 4. Build and install the unit test enabled libnvdimm modules in the


### PR DESCRIPTION
`CONFIG_DEV_DAX_PMEM=m` will be needed for compiling the libnvdimm as a module (kernel 4.15.0-rc2+)

Signed-off-by: QI Fuli <qi.fuli@jp.fujitsu.com>