### PR TITLE
util/strbuf.h: include sys/types.h for ssize_t definition.

### DIFF
--- a/util/strbuf.h
+++ b/util/strbuf.h
@@ -17,6 +17,7 @@
 #define __NDCTL_STRBUF_H
 #include <string.h>
 #include <assert.h>
+#include <sys/types.h> /* for ssize_t */
 
 /*
  * Strbuf's can be use in many ways: as a byte array, or to store arbitrary


### PR DESCRIPTION
fixes compilation on musl libc systems like Void Linux *-musl and Alpine
Linux

Build error
```
In file included from util/abspath.c:5:0:
./util/strbuf.h:68:45: error: unknown type name 'ssize_t'; did you mean 'size_t'?
 extern void strbuf_init(struct strbuf *buf, ssize_t hint);
                                             ^~~~~~~
                                             size_t
./util/strbuf.h:73:15: error: unknown type name 'ssize_t'
 static inline ssize_t strbuf_avail(const struct strbuf *sb) {
               ^~~~~~~
./util/strbuf.h:105:8: error: unknown type name 'ssize_t'
 extern ssize_t strbuf_read(struct strbuf *, int fd, ssize_t hint);
        ^~~~~~~
./util/strbuf.h:105:53: error: unknown type name 'ssize_t'; did you mean 'size_t'?
 extern ssize_t strbuf_read(struct strbuf *, int fd, ssize_t hint);
```