### PR TITLE
ndctl: fix ndctl linking with libkeyutils

### DIFF
--- a/ndctl/Makefile.am
+++ b/ndctl/Makefile.am
@@ -47,6 +47,10 @@ ndctl_LDADD =\
 	$(KMOD_LIBS) \
 	$(JSON_LIBS)
 
+if ENABLE_KEYUTILS
+ndctl_LDADD += -lkeyutils
+endif
+
 if ENABLE_TEST
 ndctl_SOURCES += ../test/libndctl.c \
 		 ../test/dsm-fail.c \

--- a/ndctl/lib/Makefile.am
+++ b/ndctl/lib/Makefile.am
@@ -30,10 +30,6 @@ libndctl_la_LIBADD =\
 	$(UUID_LIBS) \
 	$(KMOD_LIBS)
 
-if ENABLE_KEYUTILS
-libndctl_la_LIBADD += -lkeyutils
-endif
-
 EXTRA_DIST += libndctl.sym
 
 libndctl_la_LDFLAGS = $(AM_LDFLAGS) \


### PR DESCRIPTION
Compilation on Ubuntu 18.04 fails with:

  /usr/bin/ld: util/keys.o: undefined reference to symbol 'keyctl_read_alloc@@KEYUTILS_0.3'
  /lib/x86_64-linux-gnu/libkeyutils.so.1: error adding symbols: DSO missing from command line

Seems like libkeyutils is incorrectly linked against libndctl,
where in reality it's the ndctl application that uses keyutils.