### PR TITLE
ndctl: fix memory leak in libndctl

### DIFF
--- a/ndctl/lib/libndctl.c
+++ b/ndctl/lib/libndctl.c
@@ -518,6 +518,7 @@ static void __free_pfn(struct ndctl_pfn *pfn, struct list_head *head, void *to_f
 	free(pfn->pfn_path);
 	free(pfn->pfn_buf);
 	free(pfn->bdev);
+	free(pfn->alignments.supported);
 	free(to_free);
 }
 


### PR DESCRIPTION
leak found by PMDK test suite:
==29103== 48 bytes in 4 blocks are definitely lost in loss record 3 of 3
==29103==    at 0x4C31C15: realloc (vg_replace_malloc.c:785)
==29103==    by 0x5B76F74: parse_lbasize_supported.isra.11 (libndctl.c:4378)
==29103==    by 0x5B78967: __add_pfn (libndctl.c:4830)
==29103==    by 0x5B7FBEC: add_dax (libndctl.c:4882)
==29103==    by 0x5B71959: __sysfs_device_parse (sysfs.c:118)
==29103==    by 0x5B78683: device_parse (libndctl.c:725)
==29103==    by 0x5B78683: daxs_init (libndctl.c:3833)
==29103==    by 0x5B7FB6F: ndctl_dax_get_first (libndctl.c:5248)
==29103==    by 0x5B80000: ndctl_namespace_get_dax (libndctl.c:3543)
==29103==    by 0x4E4CA7E: os_dimm_region_namespace (os_dimm_ndctl.c:131)
==29103==    by 0x4E4CD0D: os_dimm_interleave_set (os_dimm_ndctl.c:194)
==29103==    by 0x4E4CE92: os_dimm_uid (os_dimm_ndctl.c:230)
==29103==    by 0x4E5F632: shutdown_state_add_part (shutdown_state.c:112)

Ref: pmem/issues#1020
Reported-by: Grzegorz Brzeziński <grzegorz.brzezinski@intel.com>
Signed-off-by: Łukasz Plewa <lukasz.plewa@intel.com>