### PR TITLE
don't try to reconfig a inactive/destroyed namespace

### DIFF
--- a/ndctl/namespace.c
+++ b/ndctl/namespace.c
@@ -1042,6 +1042,9 @@ static int namespace_reconfig(struct ndctl_region *region,
 	rc = validate_namespace_options(region, ndns, &p);
 	if (rc)
 		return rc;
+	/* check if ndns is inactive/destroyed */
+	if (p.size == 0)
+		return -ENXIO;
 
 	rc = namespace_destroy(region, ndns);
 	if (rc < 0)


### PR DESCRIPTION
In namespace_reconfig, quit early if input namespace is of size 0
(inactive/destroyed), specifically setup_namespace should not be called.
