### PR TITLE
Fixed typo in Documentation/daxctl/movable-options.txt

### DIFF
--- a/Documentation/daxctl/movable-options.txt
+++ b/Documentation/daxctl/movable-options.txt
@@ -2,7 +2,7 @@
 
 --no-movable::
 	'--movable' is the default. This can be overridden to online new
-	memory such that is is not 'movable'. This allows any allocation
+	memory such that it is not 'movable'. This allows any allocation
 	to potentially be served from this memory. This may preclude subsequent
 	removal. With the '--movable' behavior (which is default), kernel
 	allocations will not consider this memory, and it will be reserved


### PR DESCRIPTION
Resolving a simple typo in the man page documentation.