### PR TITLE
Documentation/ndctl: add more sub-commands reference to create-namespace

### DIFF
--- a/Documentation/ndctl/ndctl-create-namespace.txt
+++ b/Documentation/ndctl/ndctl-create-namespace.txt
@@ -258,5 +258,7 @@ linkndctl:ndctl-zero-labels[1],
 linkndctl:ndctl-init-labels[1],
 linkndctl:ndctl-disable-namespace[1],
 linkndctl:ndctl-enable-namespace[1],
+linkndctl:ndctl-destroy-namespace[1].
+linkndctl:ndctl-check-namespace[1].
 http://www.uefi.org/sites/default/files/resources/UEFI_Spec_2_7.pdf[UEFI NVDIMM Label Protocol]
 https://nvdimm.wiki.kernel.org[Linux Persistent Memory Wiki]


### PR DESCRIPTION
The man manual of ndctl create-namespace did not mention ndctl
destory-namespace and check-namespace sub-commands in the See Also
section. This patch is to add them.

This PR is to solve Issue 128
https://github.com/pmem/ndctl/issues/128