### PR TITLE
Documentation/ndctl: fix self-reference of ndctl disable-namespace

### DIFF
--- a/Documentation/ndctl/ndctl-disable-namespace.txt
+++ b/Documentation/ndctl/ndctl-disable-namespace.txt
@@ -22,4 +22,4 @@ include::../copyright.txt[]
 
 SEE ALSO
 --------
-linkndctl:ndctl-disable-namespace[1]
+linkndctl:ndctl-enable-namespace[1]


### PR DESCRIPTION
The man manual of ndctl disable-namespace link to itself at See Also section.
It should be enable-namespace instead of it.

This PR is to fix issue 127.
https://github.com/pmem/ndctl/issues/127