### PR TITLE
Fix gitignore not to chase modification of attr.adoc and iomem.lo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Documentation/daxctl/asciidoc.conf
 Documentation/ndctl/asciidoc.conf
 Documentation/daxctl/asciidoctor-extensions.rb
 Documentation/ndctl/asciidoctor-extensions.rb
+Documentation/ndctl/attrs.adoc
 .dirstamp
 daxctl/config.h
 daxctl/daxctl
@@ -31,6 +32,7 @@ rhel/
 sles/ndctl.spec
 util/log.lo
 util/sysfs.lo
+util/iomem.lo
 version.m4
 *.swp
 cscope.files


### PR DESCRIPTION
Documentation/ndctl/attrs.adoc and util/iomem.lo are generated at build.
Then, they should be ignored from git.