### PR TITLE
configure.ac: Use standard --with-bash-completion-dir option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,19 +133,22 @@ PKG_CHECK_MODULES([UUID], [uuid],
 	[AC_DEFINE([HAVE_UUID], [1], [Define to 1 if using libuuid])])
 PKG_CHECK_MODULES([JSON], [json-c])
 
-AC_ARG_WITH([bash],
-	AS_HELP_STRING([--with-bash],
-		[Enable bash auto-completion. @<:@default=yes@:>@]),
+AC_ARG_WITH([bash-completion-dir],
+	AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+		[Enable bash auto-completion. Uses pkgconfig if no path given. @<:@default=yes@:>@]),
 	[],
-	[with_bash=yes])
+	[with_bash_completion_dir=yes])
 
-if test "x$with_bash" = "xyes"; then
+if test "x$with_bash_completion_dir" = "xyes"; then
 	PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
-		[BASH_COMPLETION_DIR=$($PKG_CONFIG --variable=completionsdir bash-completion)], [])
+		[BASH_COMPLETION_DIR=$($PKG_CONFIG --variable=completionsdir bash-completion)],
+		[BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
+else
+	BASH_COMPLETION_DIR="$with_bash_completion_dir"
 fi
 
 AC_SUBST([BASH_COMPLETION_DIR])
-AM_CONDITIONAL([ENABLE_BASH_COMPLETION], [test "x$with_bash" = "xyes"])
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION], [test "x$with_bash_completion_dir" != "xno"])
 
 AC_ARG_ENABLE([local],
         AS_HELP_STRING([--disable-local], [build against kernel ndctl.h @<:@default=system@:>@]),


### PR DESCRIPTION
Rationale:
This makes it a lot easier to enable/disable installation
of bash completion files rather than it being based on
a certain package being installed (or not). It's useful
in Gentoo Linux for example where we may want to always
install Bash completion files to the right location, even
if the user isn't using it yet, to save rebuilds.

This makes a few changes to the current Bash completion logic, mainly:
* Falls back gracefully to a standard directory if bash-completion
  itself is not installed (in that case, we can't ask it via pkgconfig
  where to place files).

* So the behaviour is now:
  * no argument / --with-bash-completion-dir=yes:

    Asks pkgconfig, but falls back to standard directory.

  * --with-bash-completion-dir=dir:

    Use the given directory with no detection.

  * --without-bash-completion-dir:

    No installation of Bash completion files.

Signed-off-by: Sam James <sam@gentoo.org>