### PR TITLE
Fix iniparser.h include

### DIFF
--- a/util/parse-configs.c
+++ b/util/parse-configs.c
@@ -4,7 +4,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <iniparser/iniparser.h>
+#include <iniparser.h>
 #include <sys/stat.h>
 #include <util/parse-configs.h>
 #include <util/strbuf.h>


### PR DESCRIPTION
In configure.ac `iniparser.h` was checked without a path too, this change makes it consistent and fixes building on Arch Linux which has the header installed in /usr/include directly.