### PR TITLE
Update ndctl.spec to allow flatpak builds

### DIFF
--- a/ndctl.spec.in
+++ b/ndctl.spec.in
@@ -38,6 +38,9 @@ subsystem defines a kernel device model and control message interface for
 platform NVDIMM resources like those defined by the ACPI 6+ NFIT (NVDIMM
 Firmware Interface Table).
 
+%if 0%{?flatpak}
+%global _udevrulesdir %{_prefix}/lib/udev/rules.d
+%endif
 
 %package -n DNAME
 Summary:	Development files for libndctl
@@ -206,7 +209,7 @@ libcxl is a library for enumerating and communicating with CXL devices.
 %{_libdir}/libcxl.so
 %{_libdir}/pkgconfig/libcxl.pc
 %{_mandir}/man3/cxl*
-%{_mandir}/man3/libcxl.3.gz
+%{_mandir}/man3/libcxl.3*
 
 
 %changelog


### PR DESCRIPTION
This will allow ndctl to be build as dependency for some flatpak builds
on fedora systems.
See also: https://docs.fedoraproject.org/en-US/flatpak/troubleshooting/#_uncompressed_manual_pages