### PR TITLE
[RFC] create-namespace: Add percentage option

### DIFF
--- a/util/size.c
+++ b/util/size.c
@@ -42,6 +42,11 @@ unsigned long long __parse_size64(const char *str, unsigned long long *units)
 			val *= SZ_1T;
 			end++;
 			break;
+		case '%':
+			if (units)
+				*units = SZ_PCT;
+			end++;
+			break;
 		default:
 			if (units)
 				*units = 1;

--- a/util/size.h
+++ b/util/size.h
@@ -19,6 +19,7 @@
 #define SZ_256M	  0x10000000
 #define SZ_1G     0x40000000
 #define SZ_1T 0x10000000000ULL
+#define SZ_PCT    0x0
 
 unsigned long long parse_size64(const char *str);
 unsigned long long __parse_size64(const char *str, unsigned long long *units);


### PR DESCRIPTION
I am not sure this option would make sense, so I 've opened an RFC/wip for discussion.

The size option of the create-namespace command can now take a percentage of
the total region size as the desired size. E.g. :

ndctl create-namespace  -s 50%

will create a namespace using half of the total region size, assuming
there is enough available capacity in the region for the request.

Only whole percentages are correctly parsed at the moment e.g. 12%, but
not 12.5%.

Sizes that result in a misaligned size with regards to region alignment
(default 16MB) are rounded down, unless the rounded-up size would result
in using the full remaining region capacity available.

Fixes: https://github.com/pmem/ndctl/issues/199
Signed-off-by: Vasilis Liaskovitis <vliaskovitis@suse.com>