### PR TITLE
build: should use libdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,7 @@ endif
 libdir = join_paths(prefixdir, get_option('libdir'))
 rootlibdir = get_option('rootlibdir')
 if rootlibdir == ''
-  rootlibdir = join_paths(rootprefixdir, libdir.split('/')[-1])
+  rootlibdir = join_paths(rootprefixdir, get_option('libdir'))
 endif
 datadir = prefixdir / get_option('datadir')
 includedir = prefixdir / get_option('includedir')


### PR DESCRIPTION
In case of that the `libdir` contains more than one components, `rootlibdir` would point to an incorrect path. For example, if `libdir` is `lib/x86_64-linux-gnu`, `rootlibdir` should be `/usr/lib/x86_64-linux-gnu`, but it will point to `/usr/x86_64-linux-gnu` currently.