### PR TITLE
README.md: Remove deprecated ND_BLK

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ loaded.  To build and install nfit_test.ko:
    CONFIG_ZONE_DEVICE=y
    CONFIG_LIBNVDIMM=m
    CONFIG_BLK_DEV_PMEM=m
-   CONFIG_ND_BLK=m
    CONFIG_BTT=y
    CONFIG_NVDIMM_PFN=y
    CONFIG_NVDIMM_DAX=y


### PR DESCRIPTION
ND_BLK kconfig was removed by kernel commit
f8669f1d6a86 ("nvdimm/blk: Delete the block-aperture window driver")

Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>