### PR TITLE
rpmbuild.sh: Abort script when an error occurs

### DIFF
--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -10,7 +10,7 @@ if ./git-version | grep -q dirty; then
 	exit 1
 fi
 if [ ! -f $spec ]; then
-	meson compile -C build rhel/ndctl.spec
+	meson compile -C build rhel/ndctl.spec || exit
 	spec=$(dirname $0)/build/rhel/ndctl.spec
 fi
 ./make-git-snapshot.sh


### PR DESCRIPTION
Abort early so that the really error message can be noticed easily. ==========================
$ ./rpmbuild.sh
Found CMake: /usr/bin/cmake (3.18.4)
Run-time dependency libtraceevent found: NO (tried pkgconfig and cmake)

../meson.build:147:2: ERROR: Dependency "libtraceevent" not found, tried pkgconfig and cmake

A full log can be found at /home/lizhijian/ndctl/build/meson-logs/meson-log.txt FAILED: build.ninja
...