### PR TITLE
util/json: Use json_object_get_uint64() with uint64 support

### DIFF
--- a/util/json.c
+++ b/util/json.c
@@ -75,7 +75,7 @@ static int display_size(struct json_object *jobj, struct printbuf *pbuf,
 static int display_hex(struct json_object *jobj, struct printbuf *pbuf,
 		int level, int flags)
 {
-	unsigned long long val = json_object_get_int64(jobj);
+	unsigned long long val = util_json_get_u64(jobj);
 	static char buf[32];
 
 	snprintf(buf, sizeof(buf), "\"%#llx\"", val);

--- a/util/json.h
+++ b/util/json.h
@@ -34,10 +34,18 @@ static inline struct json_object *util_json_new_u64(unsigned long long val)
 {
 	return json_object_new_uint64(val);
 }
+static inline unsigned long long util_json_get_u64(struct json_object *jobj)
+{
+	return json_object_get_uint64(jobj);
+}
 #else /* fallback to signed */
 static inline struct json_object *util_json_new_u64(unsigned long long val)
 {
 	return json_object_new_int64(val);
+}
+static inline unsigned long long util_json_get_u64(struct json_object *jobj)
+{
+	return json_object_get_int64(jobj);
 }
 #endif /* HAVE_JSON_U64 */
 #endif /* __UTIL_JSON_H__ */


### PR DESCRIPTION
If HAVE_JSON_U64=1, utils/json.c:display_hex() can call json_object_get_int64() on a struct json_object created with json_object_new_uint64(). In the context of 'ndctl list --regions --human', this results in a static value of 0x7fffffffffffffff being displayed for iset_id, as seen in #217.

Correct hex values are observed with the use of json_object_get_uint64(). To support builds against older json-c, use a new static inline function util_json_get_u64() to fallback to json_object_get_int64() if HAVE_JSON_U64=0.

Link: #217
Fixes: 691cd249 ("json: Add support for json_object_new_uint64()")

We observed the 0x7fffffffffffffff value while testing NVDIMMS with RHEL9.2 and RHEL9.3, ndctl version 71.1
```
# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="9.3 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.3"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux 9.3 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.3
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.3"
# ndctl --version
71.1
# ndctl list -Ru
[
  {
    "dev":"region1",
    "size":"1518.00 GiB (1629.94 GB)",
    "align":"96.00 MiB (100.66 MB)",
    "available_size":"1518.00 GiB (1629.94 GB)",
    "max_available_extent":"1518.00 GiB (1629.94 GB)",
    "type":"pmem",
    "iset_id":"0x7fffffffffffffff",
    "persistence_domain":"memory_controller"
  },
  {
    "dev":"region3",
    "size":"1518.00 GiB (1629.94 GB)",
    "align":"96.00 MiB (100.66 MB)",
    "available_size":"1518.00 GiB (1629.94 GB)",
    "max_available_extent":"1518.00 GiB (1629.94 GB)",
    "type":"pmem",
    "iset_id":"0x7fffffffffffffff",
    "persistence_domain":"memory_controller"
  },
  {
    "dev":"region0",
    "size":"1518.00 GiB (1629.94 GB)",
    "align":"96.00 MiB (100.66 MB)",
    "available_size":"1518.00 GiB (1629.94 GB)",
    "max_available_extent":"1518.00 GiB (1629.94 GB)",
    "type":"pmem",
    "iset_id":"0x7fffffffffffffff",
    "persistence_domain":"memory_controller"
  },
  {
    "dev":"region2",
    "size":"1518.00 GiB (1629.94 GB)",
    "align":"96.00 MiB (100.66 MB)",
    "available_size":"1518.00 GiB (1629.94 GB)",
    "max_available_extent":"1518.00 GiB (1629.94 GB)",
    "type":"pmem",
    "iset_id":"0x7fffffffffffffff",
    "persistence_domain":"memory_controller"
  }
]
```