### PR TITLE
include libgen.h for basename

### DIFF
--- a/daxctl/device.c
+++ b/daxctl/device.c
@@ -2,6 +2,7 @@
 /* Copyright (C) 2019-2020 Intel Corporation. All rights reserved. */
 #include <stdio.h>
 #include <errno.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <syslog.h>
 #include <unistd.h>


### PR DESCRIPTION
basename prototype has been removed from string.h from latest musl [1] compilers e.g. clang-18 flags the absense of prototype as error. therefore include libgen.h for providing it.

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7