### PR TITLE
ndctl/lib/libndctl.c, add read dirty_shutdown info in function popula…

### DIFF
--- a/ndctl/lib/libndctl.c
+++ b/ndctl/lib/libndctl.c
@@ -1746,6 +1746,10 @@ static int populate_cxl_dimm_attributes(struct ndctl_dimm *dimm,
 		}
 	}
 
+	sprintf(path, "%s/%s/dirty_shutdown", dimm_base, bus_prefix);
+	if (sysfs_read_attr(ctx, path, buf) == 0)
+		dimm->dirty_shutdown = strtoll(buf, NULL, 0);
+
  err_read:
 
 	free(path);


### PR DESCRIPTION
ndctl/lib/libndctl.c: add read dirty_shutdown info in populate_cxl_dimm_attributes()

First, dirty_shutdown info is an essential info and must not be defaut value when calling PMDK create-namespace command; Sencond, it is necessary to read basic dimm info from sysfs in regardless of keep it with defaut value, which is always negative and result in error in application

Note that PMDK use at link: https://github.com/pmem/pmdk/blob/master/src/libpmem2/usc_ndctl.c : int pmem2_source_device_usc()->ndctl_dimm_get_dirty_shutdown()