### PR TITLE
Enable libtraceevent/libtracefs support for Fedora

### DIFF
--- a/ndctl.spec.in
+++ b/ndctl.spec.in
@@ -10,7 +10,7 @@ Requires:	LNAME%{?_isa} = %{version}-%{release}
 Requires:	DAX_LNAME%{?_isa} = %{version}-%{release}
 Requires:	CXL_LNAME%{?_isa} = %{version}-%{release}
 BuildRequires:	autoconf
-%if 0%{?rhel} < 9
+%if 0%{?rhel} && 0%{?rhel} < 9
 BuildRequires:	asciidoc
 %define asciidoctor -Dasciidoctor=disabled
 %define libtracefs -Dlibtracefs=disabled


### PR DESCRIPTION
As noted in https://src.fedoraproject.org/rpms/ndctl/pull-request/2, the expression `0%{?rhel}` evaluates to zero on Fedora, so the conditional `%if 0%{?rhel} < 9` evaluates to true, since 0 is less than 9. The result is that ndctl builds for Fedora lack support for libtraceevent and libtracefs, which is fixed by this PR.
