### PR TITLE
libcxl: remove nonexistent symbol declaration

### DIFF
--- a/cxl/lib/libcxl.sym
+++ b/cxl/lib/libcxl.sym
@@ -208,7 +208,6 @@ global:
 	cxl_mapping_get_first;
 	cxl_mapping_get_next;
 	cxl_mapping_get_decoder;
-	cxl_mapping_get_region;
 	cxl_mapping_get_position;
 	cxl_decoder_get_by_name;
 	cxl_decoder_get_memdev;

--- a/cxl/libcxl.h
+++ b/cxl/libcxl.h
@@ -354,7 +354,6 @@ struct cxl_memdev_mapping *cxl_mapping_get_first(struct cxl_region *region);
 struct cxl_memdev_mapping *
 cxl_mapping_get_next(struct cxl_memdev_mapping *mapping);
 struct cxl_decoder *cxl_mapping_get_decoder(struct cxl_memdev_mapping *mapping);
-struct cxl_region *cxl_mapping_get_region(struct cxl_memdev_mapping *mapping);
 unsigned int cxl_mapping_get_position(struct cxl_memdev_mapping *mapping);
 
 #define cxl_mapping_foreach(region, mapping) \


### PR DESCRIPTION
this was added in d25dc6d7956bc022d7e4c4453416c52368df291d but has never had an implementation, and new ld.lld by default fails to link when a symbol doesn't exist:

ld.lld: error: version script assignment of 'LIBCXL_3' to symbol 'cxl_mapping_get_region' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)