### PR TITLE
cxl/json: Fix tracefs include.

### DIFF
--- a/cxl/json.c
+++ b/cxl/json.c
@@ -9,7 +9,7 @@
 #include <json-c/json.h>
 #include <json-c/printbuf.h>
 #include <ccan/short_types/short_types.h>
-#include <tracefs/tracefs.h>
+#include <tracefs.h>
 
 #include "filter.h"
 #include "json.h"


### PR DESCRIPTION
../cxl/json.c:12:10: fatal error: tracefs/tracefs.h: No such file or directory

pkg-config --cflags libtracefs
-I/usr/include/libtracefs -I/usr/include/traceevent

find /usr/include/ -name tracefs.h
/usr/include/libtracefs/tracefs.h