### PR TITLE
Pass the name defined inside the .pc file to the Meson Build System's dependency()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -158,9 +158,9 @@ if get_option('docs').enabled()
 endif
 
 if get_option('systemd').enabled()
-  systemd = dependency('systemd', required : true)
+  systemd = dependency('libsystemd', required : true)
   systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
-  udev = dependency('udev', required : true)
+  udev = dependency('libudev', required : true)
   udevdir = udev.get_pkgconfig_variable('udevdir')
   udevrulesdir = udevdir / 'rules.d'
 endif


### PR DESCRIPTION
Seen on Ubuntu 24.10. The systemd package in the corresponding .pc file has a valid name "libsystemd".
Pass the proper name that meson expects in dependency(), otherwise meson setup build step fails complaining the (canonical) package name is not found.